### PR TITLE
build: no need to add a package token when in our own org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,5 +29,4 @@ jobs:
       version_from_gradle: false
       make_release: ${{ inputs.make_release }}
     secrets:
-      PACKAGE_TOKEN: ${{ secrets.PACKAGE_TOKEN }}
       LICENSE_KEY: ${{ secrets.LICENSE_KEY }}


### PR DESCRIPTION
The package token secret is no longer needed since both the gradle plugin and SDK lib are public, GITHUB_TOKEN will have read access to those. If used outside of the org you may still set the PACKAGE_TOKEN